### PR TITLE
FIX: Change speaker number indexing from 1 to 0

### DIFF
--- a/demo/inference_from_file.py
+++ b/demo/inference_from_file.py
@@ -214,7 +214,7 @@ def main():
     # Map speaker numbers to provided speaker names
     speaker_name_mapping = {}
     speaker_names_list = args.speaker_names if isinstance(args.speaker_names, list) else [args.speaker_names]
-    for i, name in enumerate(speaker_names_list, 1):
+    for i, name in enumerate(speaker_names_list, 0):
         speaker_name_mapping[str(i)] = name
     
     print(f"\nSpeaker mapping:")


### PR DESCRIPTION
fixes:  Speaker mapping:
  Speaker 0 -> Speaker 0
  Speaker 1 -> CharlieCalm
  Speaker 2 -> CharlieMid
  Speaker 3 -> CharliePassion
Warning: No voice preset found for 'Speaker 0', using default voice: