### PR TITLE
Add logging and CLI control for activation-based speaker segmentation

### DIFF
--- a/demo/inference_from_file.py
+++ b/demo/inference_from_file.py
@@ -140,15 +140,17 @@ def detect_speaker_segments(
     txt_content: str,
     model: VibeVoiceForConditionalGenerationInference,
     tokenizer,
-    layer: int = 1,
+    layer: int = 0,
     dimension: int = 609,
     threshold_scale: float = 2.0,
+    min_gap_tokens: int = 20,
 ) -> Tuple[List[str], List[str]]:
     """Split raw text into speaker segments using a neuron's activation.
 
     This utility inspects the hidden activations from ``layer`` and ``dimension``
     Returns a tuple of ``(scripts, speaker_numbers)`` formatted like
-    ``parse_txt_script``.
+    ``parse_txt_script``. ``min_gap_tokens`` guards against rapid successive
+    crossings that would otherwise create many small segments.
     """
 
     encoded = tokenizer(txt_content, return_tensors="pt")
@@ -163,7 +165,30 @@ def detect_speaker_segments(
 
     hidden = outputs.hidden_states[layer + 1][0, :, dimension].cpu()
     threshold = hidden.mean() + threshold_scale * hidden.std()
-    transitions = (hidden > threshold).nonzero(as_tuple=True)[0].tolist()
+    above = hidden > threshold
+    crossing_indices = ((~above[:-1]) & above[1:]).nonzero(as_tuple=True)[0] + 1
+
+    transitions: List[int] = []
+    last_idx = -min_gap_tokens
+    for idx in crossing_indices.tolist():
+        if idx - last_idx >= min_gap_tokens:
+            transitions.append(idx)
+            last_idx = idx
+
+    logger.info(
+        "Activation threshold %.4f (mean %.4f + %.2f * std %.4f)",
+        threshold,
+        hidden.mean(),
+        threshold_scale,
+        hidden.std(),
+    )
+    if transitions:
+        for idx in transitions:
+            logger.info(
+                "Transition at token %d with activation %.4f", idx, hidden[idx]
+            )
+    else:
+        logger.info("No transitions exceeded the threshold")
 
     tokens = input_ids[0].cpu().tolist()
     scripts, speaker_numbers = [], []
@@ -236,6 +261,31 @@ def parse_args():
         "--auto_detect",
         action="store_true",
         help="Automatically detect speaker transitions using activation",
+    )
+
+    parser.add_argument(
+        "--activation_layer",
+        type=int,
+        default=0,
+        help="Layer index to probe for speaker segmentation",
+    )
+    parser.add_argument(
+        "--activation_dimension",
+        type=int,
+        default=609,
+        help="Neuron dimension to probe for speaker segmentation",
+    )
+    parser.add_argument(
+        "--activation_threshold_scale",
+        type=float,
+        default=2.0,
+        help="Scale factor applied to std when computing activation threshold",
+    )
+    parser.add_argument(
+        "--activation_min_gap_tokens",
+        type=int,
+        default=20,
+        help="Minimum tokens between detected transitions to avoid spurious splits",
     )
 
     return parser.parse_args()
@@ -331,7 +381,15 @@ def main():
     # Determine segments either via auto detection or pre-labelled script
     if args.auto_detect:
         print("Detecting speaker transitions from activation...")
-        scripts, speaker_numbers = detect_speaker_segments(txt_content, model, processor.tokenizer)
+        scripts, speaker_numbers = detect_speaker_segments(
+            txt_content,
+            model,
+            processor.tokenizer,
+            layer=args.activation_layer,
+            dimension=args.activation_dimension,
+            threshold_scale=args.activation_threshold_scale,
+            min_gap_tokens=args.activation_min_gap_tokens,
+        )
     else:
         scripts, speaker_numbers = parse_txt_script(txt_content)
 


### PR DESCRIPTION
## Summary
- refine activation-based segmentation by detecting rising-edge threshold crossings and enforcing a minimum token gap
- expose `--activation_min_gap_tokens` CLI option to limit rapid transitions